### PR TITLE
길잡이

### DIFF
--- a/Gugujj.xcodeproj/project.pbxproj
+++ b/Gugujj.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F67681D2848EADE00F58EE6 /* Location.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F67681C2848EADE00F58EE6 /* Location.swift */; };
 		5A1F03BB28449AD9005622FF /* Temple.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F03BA28449AD9005622FF /* Temple.swift */; };
 		5A40BCE3283C671200DB7FC4 /* RectangleTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A40BCE1283C671200DB7FC4 /* RectangleTableViewCell.swift */; };
 		5A40BCE4283C671200DB7FC4 /* RectangleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5A40BCE2283C671200DB7FC4 /* RectangleTableViewCell.xib */; };
@@ -29,6 +30,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2F67681C2848EADE00F58EE6 /* Location.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Location.swift; sourceTree = "<group>"; };
 		5A1F03BA28449AD9005622FF /* Temple.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Temple.swift; sourceTree = "<group>"; };
 		5A40BCE1283C671200DB7FC4 /* RectangleTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RectangleTableViewCell.swift; sourceTree = "<group>"; };
 		5A40BCE2283C671200DB7FC4 /* RectangleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RectangleTableViewCell.xib; sourceTree = "<group>"; };
@@ -67,6 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				5A1F03BA28449AD9005622FF /* Temple.swift */,
+				2F67681C2848EADE00F58EE6 /* Location.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -218,6 +221,7 @@
 				94396C9028448EC50088F303 /* BaseViewController.swift in Sources */,
 				5A40BCE6283C7F1900DB7FC4 /* TempleViewController.swift in Sources */,
 				5AE55B23283B5F6900D19FFF /* UserViewController.swift in Sources */,
+				2F67681D2848EADE00F58EE6 /* Location.swift in Sources */,
 				94B16BDC2840BEA400D57CDE /* CommonURL.swift in Sources */,
 				94B16BDA2840BE9300D57CDE /* CommonHttp.swift in Sources */,
 				5A1F03BB28449AD9005622FF /* Temple.swift in Sources */,
@@ -373,7 +377,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7HH6MYUS98;
+				DEVELOPMENT_TEAM = 68YKCTN88M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gugujj/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -401,7 +405,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 7HH6MYUS98;
+				DEVELOPMENT_TEAM = 68YKCTN88M;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Gugujj/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Gugujj/Base.lproj/Main.storyboard
+++ b/Gugujj/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tTA-xl-HvG">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="tTA-xl-HvG">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>

--- a/Gugujj/Cell/RectangleTableViewCell.swift
+++ b/Gugujj/Cell/RectangleTableViewCell.swift
@@ -43,8 +43,10 @@ class RectangleTableViewCell: UITableViewCell {
             self.title.text = temple.title
             self.address.text = temple.addr1
             
-            let data = try? Data(contentsOf: URL(string: temple.imageUrl!)!)
-            self.thumbnail.image = UIImage(data: data!)
+            if let imageUrl = temple.imageUrl {
+                let data = try? Data(contentsOf: URL(string: temple.imageUrl!)!)
+                self.thumbnail.image = UIImage(data: data!)
+            }
         }
     }
     

--- a/Gugujj/Common/CommonHttp.swift
+++ b/Gugujj/Common/CommonHttp.swift
@@ -11,20 +11,18 @@ class CommonHttp {
     
     // 지역기반 관광정보
     // http://api.visitkorea.or.kr/openapi/service/rest/KorService/areaBasedList?serviceKey=A9SNzq25jbRcOZjQbyQJDJ0%2FBj7XHXlyRYCj9zZ0QiXhu9uK8AK8NxRagU7ocRKlZ83jLsvZ1q%2BxoAQinn3pIQ%3D%3D&pageNo=1&numOfRows=10&MobileApp=AppTest&MobileOS=ETC&arrange=P&cat1=A02&contentTypeId=12&cat2=A0201&cat3=A02010800&listYN=Y
-    static func getAreaBasedList(completion: @escaping (Data) -> (Void)) {
-        var params: [String:String] = [:]
-        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
-        params.updateValue("1", forKey: "pageNo")
-        params.updateValue("10", forKey: "numOfRows")
-        params.updateValue("AppTest", forKey: "MobileApp")
-        params.updateValue("ETC", forKey: "MobileOS")
+    static func getAreaBasedList(areaCode: String? = nil, completion: @escaping (Data) -> (Void)) {
+        var params: [String:String] = getCommonParams()
         params.updateValue("P", forKey: "arrange")
         params.updateValue("A02", forKey: "cat1")
         params.updateValue("12", forKey: "contentTypeId")
         params.updateValue("A0201", forKey: "cat2")
         params.updateValue("A02010800", forKey: "cat3")
         params.updateValue("Y", forKey: "listYN")
-
+        if let areaCode = areaCode {
+            params.updateValue(areaCode, forKey: "areaCode")
+        }
+        
         dataTask(baseUrl: CommonURL.AREA_BASED_URL, category: "areaBasedList", params: params) { passingData in
             completion(passingData)
         }
@@ -33,12 +31,7 @@ class CommonHttp {
     // 공통정보
     // http://api.visitkorea.or.kr/openapi/service/rest/KorService/detailCommon?ServiceKey=A9SNzq25jbRcOZjQbyQJDJ0%2FBj7XHXlyRYCj9zZ0QiXhu9uK8AK8NxRagU7ocRKlZ83jLsvZ1q%2BxoAQinn3pIQ%3D%3D&contentTypeId=12&contentId=294452&MobileOS=ETC&MobileApp=AppTest&defaultYN=Y&firstImageYN=Y&areacodeYN=Y&catcodeYN=Y&addrinfoYN=Y&mapinfoYN=Y&overviewYN=Y&transGuideYN=Y
     static func getDetailCommon(contentId: String, completion: @escaping (Data) -> (Void)) {
-        var params: [String:String] = [:]
-        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
-        params.updateValue("10", forKey: "numOfRows")
-        params.updateValue("1", forKey: "pageNo")
-        params.updateValue("ETC", forKey: "MobileOS")
-        params.updateValue("AppTest", forKey: "MobileApp")
+        var params: [String:String] = getCommonParams()
         params.updateValue(contentId, forKey: "contentId")
         params.updateValue("12", forKey: "contentTypeId")
         params.updateValue("Y", forKey: "defaultYN")
@@ -59,12 +52,7 @@ class CommonHttp {
     // 유모차 대여 여부, 신용카드 가능 여부, 애완동물 동반 가능 여부, 문의 및 안내 전화번호, 주차시설, 쉬는 날, 이용시간
     // http://api.visitkorea.or.kr/openapi/service/rest/KorService/detailIntro?serviceKey=o4SsZp9tZ%2FCG9GvxPJQ796Ngnou51GsLKBzW6c8UMjmOr1RexN%2BZGdzpJOCjozZYBVLx92BAm3xyZFvQ2eOl5Q%3D%3D&numOfRows=10&pageNo=1&MobileOS=ETC&MobileApp=AppTest&contentId=294452&contentTypeId=12
     static func getDetailIntro(contentId: String, completion: @escaping (Data) -> (Void)) {
-        var params: [String:String] = [:]
-        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
-        params.updateValue("10", forKey: "numOfRows")
-        params.updateValue("1", forKey: "pageNo")
-        params.updateValue("ETC", forKey: "MobileOS")
-        params.updateValue("AppTest", forKey: "MobileApp")
+        var params: [String:String] = getCommonParams()
         params.updateValue(contentId, forKey: "contentId")
         params.updateValue("12", forKey: "contentTypeId")
         
@@ -78,12 +66,7 @@ class CommonHttp {
     // 입장료, 화장실, 외국어 안내서비스 등
     // http://api.visitkorea.or.kr/openapi/service/rest/KorService/detailInfo?serviceKey=o4SsZp9tZ%2FCG9GvxPJQ796Ngnou51GsLKBzW6c8UMjmOr1RexN%2BZGdzpJOCjozZYBVLx92BAm3xyZFvQ2eOl5Q%3D%3D&numOfRows=10&pageNo=1&MobileOS=ETC&MobileApp=AppTest&contentId=294452&contentTypeId=12
     static func getDetailInfo(contentId: String, completion: @escaping (Data) -> (Void)) {
-        var params: [String:String] = [:]
-        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
-        params.updateValue("10", forKey: "numOfRows")
-        params.updateValue("1", forKey: "pageNo")
-        params.updateValue("ETC", forKey: "MobileOS")
-        params.updateValue("AppTest", forKey: "MobileApp")
+        var params: [String:String] = getCommonParams()
         params.updateValue(contentId, forKey: "contentId")
         params.updateValue("12", forKey: "contentTypeId")
         
@@ -95,12 +78,7 @@ class CommonHttp {
     // 이미지정보
     // http://api.visitkorea.or.kr/openapi/service/rest/KorService/detailImage?serviceKey=o4SsZp9tZ%2FCG9GvxPJQ796Ngnou51GsLKBzW6c8UMjmOr1RexN%2BZGdzpJOCjozZYBVLx92BAm3xyZFvQ2eOl5Q%3D%3D&numOfRows=10&pageNo=1&MobileOS=ETC&MobileApp=AppTest&contentId=294452&imageYN=Y&subImageYN=Y
     static func getDetailImage(contentId: String, completion: @escaping (Data) -> (Void)) {
-        var params: [String:String] = [:]
-        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
-        params.updateValue("10", forKey: "numOfRows")
-        params.updateValue("1", forKey: "pageNo")
-        params.updateValue("ETC", forKey: "MobileOS")
-        params.updateValue("AppTest", forKey: "MobileApp")
+        var params: [String:String] = getCommonParams()
         params.updateValue(contentId, forKey: "contentId")
         params.updateValue("Y", forKey: "imageYN")
         params.updateValue("Y", forKey: "subImageYN")
@@ -135,5 +113,15 @@ class CommonHttp {
         }
         //result.dropLast()
         return result
+    }
+    
+    static private func getCommonParams() -> [String:String] {
+        var params: [String:String] = [:]
+        params.updateValue(CommonURL.API_KEY, forKey: "serviceKey")
+        params.updateValue("10", forKey: "numOfRows")
+        params.updateValue("1", forKey: "pageNo")
+        params.updateValue("ETC", forKey: "MobileOS")
+        params.updateValue("AppTest", forKey: "MobileApp")
+        return params
     }
 }

--- a/Gugujj/Model/Location.swift
+++ b/Gugujj/Model/Location.swift
@@ -1,0 +1,99 @@
+//
+//  Location.swift
+//  Gugujj
+//
+//  Created by EunTak.Oh on 2022/06/02.
+//
+
+/// 서울 1
+/// 인천 2
+/// 대전 3
+/// 대구 4
+/// 광주 5
+/// 부산 6
+/// 울산 7
+/// 세종특별자치시 8
+/// 경기도 31
+/// 강원도 32
+/// 충청북도 33
+/// 충청남도 34
+/// 경상북도 35
+/// 경상남도 36
+/// 전라북도 37
+/// 전라남도 38
+/// 제주도 39
+import Foundation
+
+enum Location {
+    case SEOUL, INCHEON, DAEJEON, DAEGU, GWANGJU, BUSAN, ULSAN, SEJONG, GYUNGGI, GANGWON, CHOONGCHUNG_NORTH, CHOONGCHUNG_SOUTH ,GYUNGSANG_NORTH, GYUNGSANG_SOUTH, JEOLA_NORTH, JEOLA_SOUTH, JEJU
+    
+    var name: String {
+        switch self {
+            case .SEOUL: return "서울"
+            case .INCHEON: return "인천"
+            case .DAEJEON: return "대전"
+            case .DAEGU: return "대구"
+            case .GWANGJU: return "광주"
+            case .BUSAN: return "부산"
+            case .ULSAN: return "울산"
+            case .SEJONG: return "세종"
+            case .GYUNGGI: return "경기"
+            case .GANGWON: return "강원"
+            case .CHOONGCHUNG_NORTH: return "충청북도"
+            case .CHOONGCHUNG_SOUTH: return "충청남도"
+            case .GYUNGSANG_NORTH: return "경상북도"
+            case .GYUNGSANG_SOUTH: return "경상남도"
+            case .JEOLA_NORTH: return "전라북도"
+            case .JEOLA_SOUTH: return "전라북도"
+            case .JEJU: return "제주"
+        }
+    }
+    
+    var areaCode: String {
+        switch self {
+            case .SEOUL: return "1"
+            case .INCHEON: return "2"
+            case .DAEJEON: return "3"
+            case .DAEGU: return "4"
+            case .GWANGJU: return "5"
+            case .BUSAN: return "6"
+            case .ULSAN: return "7"
+            case .SEJONG: return "8"
+            case .GYUNGGI: return "31"
+            case .GANGWON: return "32"
+            case .CHOONGCHUNG_NORTH: return "33"
+            case .CHOONGCHUNG_SOUTH: return "34"
+            case .GYUNGSANG_NORTH: return "35"
+            case .GYUNGSANG_SOUTH: return "36"
+            case .JEOLA_NORTH: return "37"
+            case .JEOLA_SOUTH: return "38"
+            case .JEJU: return "39"
+        }
+    }
+    
+    func getLocation(index: Int) -> Location {
+        switch index {
+        case 0: return .SEOUL
+        case 1: return .INCHEON
+        case 2: return .DAEJEON
+        case 3: return .DAEGU
+        case 4: return  .GWANGJU
+        case 5: return .BUSAN
+        case 6: return .ULSAN
+        case 7: return .SEJONG
+        case 8: return .GYUNGGI
+        case 9: return .GANGWON
+        case 10: return .CHOONGCHUNG_NORTH
+        case 11: return .CHOONGCHUNG_SOUTH
+        case 12: return .GYUNGSANG_NORTH
+        case 13: return .GYUNGSANG_SOUTH
+        case 14: return .JEOLA_NORTH
+        case 15: return .JEOLA_SOUTH
+        case 16: return .JEJU
+        default:
+            return .SEOUL
+        }
+    }
+    
+    static var totalCount: Int = 17
+}

--- a/Gugujj/VC/BaseViewController.swift
+++ b/Gugujj/VC/BaseViewController.swift
@@ -20,12 +20,12 @@ class BaseViewController: UIViewController {
     }
     
     private func setScreenEdgePanGestureRecognizer() {
-        screenLeftEdgeRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(rotateBall(_:)))
+        screenLeftEdgeRecognizer = UIScreenEdgePanGestureRecognizer(target: self, action: #selector(tabGestureScreenEdge(_:)))
         screenLeftEdgeRecognizer.edges = .left
         view.addGestureRecognizer(screenLeftEdgeRecognizer)
     }
     
-    @objc func rotateBall(_ sender: UIScreenEdgePanGestureRecognizer) {
+    @objc func tabGestureScreenEdge(_ sender: UIScreenEdgePanGestureRecognizer) {
         if !isSwipedFlag {
             CommonNavi.popVC()
             isSwipedFlag = true


### PR DESCRIPTION
EdgeScreenPanGesture Selector 함수명 정정.
Location Enum 객체 생성, PickerView, 공공데이터 API 파라미터 연결.
CommonHttp 공통 파라미터 함수화.
PickerView 선택 시 지역기반 재검색 로직 추가.

지역 PickerView 선택 시 Temple Array 초기화 및 TempleTableView reload 하도록 변경하였습니다.
Location 데이터를 객체화하여 PickerView와 공공데이터 api 파라미터에 사용하도록 하였는데 약간 맘에 안드는 부분이 있어서 다시 고칠 수도 있어요..
이번에 제가 변경하면서 사용안하게 된 부분은 주석처리하였습니다. 
이제 하셔야 되는 부분은 리스트 맨 아래까지 스크롤 하였을 때 다음 페이지의 데이터를 로드하여 테이블뷰 컨텐츠를 연장시키는 것입니다.
잘하고 계세요~🙏 이대로만 계속 홧팅~🙆